### PR TITLE
Fix Last Downloads Order to show last not first

### DIFF
--- a/src/newshows/helpers.py
+++ b/src/newshows/helpers.py
@@ -38,7 +38,7 @@ def getSonarrDownloads(SONARR_URL, SONARR_APIKEY):
     lstDownloads = list()
     dictShow = dict()
     endpoint = "/history/"
-    url = settings.SONARR_URL + endpoint + "?apikey=" + settings.SONARR_APIKEY + "&sortKey=date"
+    url = settings.SONARR_URL + endpoint + "?apikey=" + settings.SONARR_APIKEY
     statuscode, sonarr = _requestURL(url)
     if statuscode == 200 and sonarr:
         logger.info("History from Sonarr fetched.")


### PR DESCRIPTION
With the sortkey on line 41, the response is the first downloads not the last